### PR TITLE
Fix: cannot unmarshal int-like `V2rayNode.V` and `V2rayNode.Aid` string

### DIFF
--- a/v2ray.go
+++ b/v2ray.go
@@ -1,6 +1,7 @@
 package v2raypool
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -9,7 +10,7 @@ import (
 // "protocol":"vmess"
 type V2rayNode struct {
 	Protocol, Add, Host, Id, Net, Path, Ps, Tls, Type string
-	V, Aid                                            int
+	V, Aid                                            json.Number
 	Port                                              any
 }
 

--- a/v2ray_api.go
+++ b/v2ray_api.go
@@ -178,8 +178,11 @@ func (a V2rayApiClient) AddOutboundByV2rayNode(nd V2rayNode, outag string) error
 					User: []*protocol.User{
 						{
 							Account: serial.ToTypedMessage(&vmess.Account{
-								Id:      nd.Id,
-								AlterId: uint32(nd.Aid),
+								Id: nd.Id,
+								AlterId: func() uint32 {
+									aid, _ := strconv.ParseUint(nd.Aid.String(), 10, 32)
+									return uint32(aid)
+								}(),
 								SecuritySettings: &protocol.SecurityConfig{
 									Type: protocol.SecurityType_AES128_GCM,
 								},


### PR DESCRIPTION
发现有些 vmess 的 v 和 aid 是字符串数字，而不是 int 。

如：

```json
{
  "v": "2",
  "ps": "美国0",
  "add": "abc.com",
  "port": "80",
  "id": "aaaa-bbbb-cccc",
  "aid": "0",
  "net": "ws",
  "type": "none",
  "host": "abc.com",
  "path": "/direct?ed=1024",
  "tls": ""
}
```